### PR TITLE
大佬，发现您的项目引入了org.elasticsearch:elasticsearch@7.13.1组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -82,7 +80,7 @@
         <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
-            <version>7.13.1</version>
+            <version>7.14.0</version>
         </dependency>
         <dependency>
             <groupId>com.alibaba</groupId>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Elasticsearch 安全漏洞
缺陷组件：org.elasticsearch:elasticsearch@7.13.1
漏洞编号：CVE-2021-22145
漏洞描述：Elasticsearch是荷兰Elasticsearch公司的一套基于Lucene构建的开源分布式RESTful搜索引擎。该产品主要应用于云计算，并支持通过HTTP使用JSON进行数据索引。
Elasticsearch 中存在安全漏洞。目前尚无此漏洞的相关信息，请随时关注CNNVD或厂商公告。以下产品及版本受到影响：
影响范围：[7.10.0, 7.13.4)
最小修复版本：7.14.0
缺陷组件引入路径：com.miex:Assess@1.0-SNAPSHOT->org.elasticsearch:elasticsearch@7.13.1
```
另外我运行这个项目时，IDE的安全插件提示还有98个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p9acd8